### PR TITLE
Specify an existing node to "wrap"

### DIFF
--- a/init.yml.tmpl
+++ b/init.yml.tmpl
@@ -60,6 +60,10 @@ data:
       listen [::]:80;
       server_name  _;
 
+      location = / {
+        return 200 "";
+      }
+
       location / {
         proxy_pass http://NODE_TO_SECURE-unprotected;
         proxy_http_version 1.1;

--- a/init.yml.tmpl
+++ b/init.yml.tmpl
@@ -51,14 +51,27 @@ data:
       '' close;
     }
 
+    upstream NODE_TO_SECURE-unprotected {
+      server NODE_TO_SECURE:PORT_SECURED_NODE max_fails=0 fail_timeout=1s;
+    }
+
     server {
       listen 80;
       listen [::]:80;
       server_name  _;
 
       location / {
-        add_header Content-Type text/plain;
-        return 200 "{}";
+        proxy_pass http://NODE_TO_SECURE-unprotected;
+        proxy_http_version 1.1;
+        proxy_set_header upgrade $http_upgrade;
+        proxy_set_header connection $connection_upgrade;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header x-forwarded-host $http_host;
+        proxy_set_header x-real-ip $remote_addr;
+        proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
+        proxy_set_header x-forwarded-protocol $scheme;
+        proxy_set_header x-forwarded-proto $scheme;
       }
     }
 ---

--- a/no_http.yml.tmpl
+++ b/no_http.yml.tmpl
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: DEPLOYMENT_NAME-ingress
+  labels:
+    last_updated: "1000000000"
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - hosts:
+    - DOMAINS_VALUE
+    secretName: DEPLOYMENT_NAME-lscrypt-certs
+  backend:
+    serviceName: cf-sec-nginx
+    servicePort: 80

--- a/securing.yml.tmpl
+++ b/securing.yml.tmpl
@@ -90,7 +90,7 @@ data:
     server {
       listen 80;
       listen [::]:80;
-      server_name  _;
+      server_name _;
 
       location / {
         proxy_pass http://NODE_TO_SECURE-protected;

--- a/securing.yml.tmpl
+++ b/securing.yml.tmpl
@@ -83,14 +83,27 @@ data:
       server DEPLOYMENT_NAME-lscrypt:80 max_fails=0 fail_timeout=1s;
     }
 
+    upstream NODE_TO_SECURE-protected {
+      server NODE_TO_SECURE:PORT_SECURED_NODE max_fails=0 fail_timeout=1s;
+    }
+
     server {
       listen 80;
       listen [::]:80;
       server_name  _;
 
       location / {
-        add_header Content-Type text/plain;
-        return 200 "{}";
+        proxy_pass http://NODE_TO_SECURE-protected;
+        proxy_http_version 1.1;
+        proxy_set_header upgrade $http_upgrade;
+        proxy_set_header connection $connection_upgrade;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header x-forwarded-host $http_host;
+        proxy_set_header x-real-ip $remote_addr;
+        proxy_set_header x-forwarded-for $proxy_add_x_forwarded_for;
+        proxy_set_header x-forwarded-protocol $scheme;
+        proxy_set_header x-forwarded-proto $scheme;
       }
 
       location ^~ /.well-known/acme-challenge/ {

--- a/securing.yml.tmpl
+++ b/securing.yml.tmpl
@@ -92,6 +92,10 @@ data:
       listen [::]:80;
       server_name _;
 
+      location = / {
+        return 200 "";
+      }
+
       location / {
         proxy_pass http://NODE_TO_SECURE-protected;
         proxy_http_version 1.1;

--- a/setup
+++ b/setup
@@ -17,7 +17,9 @@ GCLOUD_ACCOUNT=$2
 DEPLOYMENT_NAME=$3
 DOMAIN=$4
 DOMAIN_EMAIL=$5
-PRODUCTION_MODE=$6
+NODE_TO_SECURE=$6
+PORT_SECURED_NODE=$7
+PRODUCTION_MODE=$8
 
 if [[ -z $GCLOUD_PROJECT ]]; then
   echo "Please specify a Gcloud project name as arg 1."
@@ -44,6 +46,16 @@ if [[ -z $DOMAIN_EMAIL ]]; then
   exit 5
 fi
 
+if [[ -z $NODE_TO_SECURE ]]; then
+  echo "Please specify the name of the node to secure inside the cluster as arg 6."
+  exit 6
+fi
+
+if [[ -z $PORT_SECURED_NODE ]]; then
+  echo "Please specify the port of the backend node to secure (currently port it is listening) as arg 7."
+  exit 7
+fi
+
 if [[ -z $PRODUCTION_MODE ]]; then
   STAGING_MODE="true"
 else
@@ -52,11 +64,37 @@ fi
 
 wdir=/tmp/$DEPLOYMENT_NAME
 mkdir -p $wdir
-cat init.yml.tmpl | sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | sed s/DOMAINS_VALUE/$DOMAIN/g > $wdir/init.yml
-cat securing.yml.tmpl | sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | sed s/DOMAINS_VALUE/$DOMAIN/g | sed s/STAGING_MODE/$STAGING_MODE/g | sed s/GCLOUD_ACCOUNT/$GCLOUD_ACCOUNT/g > $wdir/securing.yml
-cat secured.yml.tmpl | sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | sed s/DOMAINS_VALUE/$DOMAIN/g > $wdir/secured.yml
-cat cleanup.yml.tmpl | sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | sed s/DOMAINS_VALUE/$DOMAIN/g | sed s/STAGING_MODE/$STAGING_MODE/g | sed s/GCLOUD_ACCOUNT/$GCLOUD_ACCOUNT/g > $wdir/cleanup.yml
-cat delete.yml.tmpl | sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | sed s/DOMAINS_VALUE/$DOMAIN/g > $wdir/delete_$DEPLOYMENT_NAME.yml
+cat init.yml.tmpl | \
+  sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \
+  sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
+  sed s/DOMAINS_VALUE/$DOMAIN/g \
+  > $wdir/init.yml
+cat securing.yml.tmpl | \
+  sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \
+  sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
+  sed s/DOMAINS_VALUE/$DOMAIN/g | \
+  sed s/STAGING_MODE/$STAGING_MODE/g | \
+  sed s/GCLOUD_ACCOUNT/$GCLOUD_ACCOUNT/g | \
+  sed s/NODE_TO_SECURE/$NODE_TO_SECURE/g \
+  sed s/PORT_SECURED_NODE/$PORT_SECURED_NODE/g \
+  > $wdir/securing.yml
+cat secured.yml.tmpl | \
+  sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \
+  sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
+  sed s/DOMAINS_VALUE/$DOMAIN/g \
+  > $wdir/secured.yml
+cat cleanup.yml.tmpl | \
+  sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \
+  sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
+  sed s/DOMAINS_VALUE/$DOMAIN/g | \
+  sed s/STAGING_MODE/$STAGING_MODE/g | \
+  sed s/GCLOUD_ACCOUNT/$GCLOUD_ACCOUNT/g \
+  > $wdir/cleanup.yml
+cat delete.yml.tmpl | \
+  sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \
+  sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
+  sed s/DOMAINS_VALUE/$DOMAIN/g \
+  > $wdir/delete_$DEPLOYMENT_NAME.yml
 
 function guard_cmd {
   set -e

--- a/setup
+++ b/setup
@@ -69,6 +69,8 @@ cat init.yml.tmpl | \
   sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \
   sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
   sed s/DOMAINS_VALUE/$DOMAIN/g \
+  sed s/NODE_TO_SECURE/$NODE_TO_SECURE/g | \
+  sed s/PORT_SECURED_NODE/$PORT_SECURED_NODE/g \
   > $wdir/init.yml
 cat securing.yml.tmpl | \
   sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \

--- a/setup
+++ b/setup
@@ -62,6 +62,7 @@ else
   STAGING_MODE=""
 fi
 
+
 wdir=/tmp/$DEPLOYMENT_NAME
 mkdir -p $wdir
 cat init.yml.tmpl | \
@@ -75,7 +76,7 @@ cat securing.yml.tmpl | \
   sed s/DOMAINS_VALUE/$DOMAIN/g | \
   sed s/STAGING_MODE/$STAGING_MODE/g | \
   sed s/GCLOUD_ACCOUNT/$GCLOUD_ACCOUNT/g | \
-  sed s/NODE_TO_SECURE/$NODE_TO_SECURE/g \
+  sed s/NODE_TO_SECURE/$NODE_TO_SECURE/g | \
   sed s/PORT_SECURED_NODE/$PORT_SECURED_NODE/g \
   > $wdir/securing.yml
 cat secured.yml.tmpl | \
@@ -95,6 +96,7 @@ cat delete.yml.tmpl | \
   sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
   sed s/DOMAINS_VALUE/$DOMAIN/g \
   > $wdir/delete_$DEPLOYMENT_NAME.yml
+
 
 function guard_cmd {
   set -e

--- a/setup
+++ b/setup
@@ -68,7 +68,7 @@ mkdir -p $wdir
 cat init.yml.tmpl | \
   sed s/DEPLOYMENT_NAME/$DEPLOYMENT_NAME/g | \
   sed s/DOMAIN_EMAIL/$DOMAIN_EMAIL/g | \
-  sed s/DOMAINS_VALUE/$DOMAIN/g \
+  sed s/DOMAINS_VALUE/$DOMAIN/g | \
   sed s/NODE_TO_SECURE/$NODE_TO_SECURE/g | \
   sed s/PORT_SECURED_NODE/$PORT_SECURED_NODE/g \
   > $wdir/init.yml


### PR DESCRIPTION
This is a simple (read naive) method to wrap an existing node.

The `setup` automation wraps the specified node, exposing HTTPS and HTTP endpoints, but it does not close endpoints to the wrapped node. Closing existing endpoints needs be done manually at this point.

An extra `no_http.yml` template allows to close the HTTP endpoint exposed by `setup`.